### PR TITLE
Adds logging facilities

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for plzwrk
 
+## 0.0.0.10
+
+- Adds logging to the parser for easier debugging.
+- Renames `hsx` to `pwx`.
+
 ## 0.0.0.9
 
 - Renames `Browserful` to `JSEnv`.
@@ -7,7 +12,7 @@
 
 ## 0.0.0.8
 
-- Fixes a bug in the HSX parser that rejected certain valid text nodes
+- Fixes a bug in the PWX parser that rejected certain valid text nodes
 
 ## 0.0.0.7
 
@@ -20,11 +25,11 @@
 ## 0.0.0.5
 
 - Adds bounds for cabal packages
-- Explicity declares `Control.Monad.Fail` in `HSX.hs` to allow automated haddock builds.
+- Explicity declares `Control.Monad.Fail` in `PWX.hs` to allow automated haddock builds.
 
 ## 0.0.0.4
 
-- Adds `hsx` and `hsx'` for `jsx`-like manipulation.
+- Adds `pwx` and `pwx'` for `jsx`-like manipulation.
 
 ## 0.0.0.3
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Available as a Hackage package: [`plzwrk`](https://hackage.haskell.org/package/p
 * [Making a webpage](#making-a-webpage)
 * [Documentation](#documentation)
 * [Design of `plzwrk`](#design-of-plzwrk)
-  * [HSX](#hsx)
+  * [PWX](#pwx)
   * [Hydrating with a state](#hydrating-with-a-state)
   * [Event handlers](#event-handlers)
 * [Server-side rendering](#server-side-rendering)
@@ -53,7 +53,7 @@ import Web.Framework.Plzwrk.Asterius
 main :: IO ()
 main = do
   browser <- asteriusBrowser
-  plzwrk'_ [hsx|<p>Hello world!</p>|] browser
+  plzwrk'_ [pwx|<p>Hello world!</p>|] browser
 ```
 
 [See the Hello World example live](https://plzwrk-hello-world.surge.sh).
@@ -84,7 +84,7 @@ The main documentation for `plzwrk` is on [Hackage](https://hackage.haskell.org/
 The four importable modules are:
 
 - [`Web.Frameworks.Plzwrk`](https://hackage.haskell.org/package/plzwrk-0.0.0.9/docs/Web-Framework-Plzwrk.html) for the basic functions
-- [`Web.Frameworks.Plzwrk.Tag`](https://hackage.haskell.org/package/plzwrk-0.0.0.9/docs/Web-Framework-Plzwrk-Tag.html) for helper functions to make takes like `input` or `br` if you are not using `hsx`.
+- [`Web.Frameworks.Plzwrk.Tag`](https://hackage.haskell.org/package/plzwrk-0.0.0.9/docs/Web-Framework-Plzwrk-Tag.html) for helper functions to make takes like `input` or `br` if you are not using `pwx`.
 - [`Web.Frameworks.Plzwrk.MockJSVal`](https://hackage.haskell.org/package/plzwrk-0.0.0.9/docs/Web-Framework-Plzwrk-MockJSVal.html) to use a mock browser.
 - [`Web.Frameworks.Plzwrk.Asterius`](https://hackage.haskell.org/package/plzwrk-0.0.0.9/docs/Web-Framework-Plzwrk-Asterius.html) to use a bindings for a real browser courtesy of [Asterius](https://github.com/tweag/asterius).
 
@@ -98,11 +98,11 @@ data MyState = MkMyState { _name :: Text, age :: Int, _tags :: [Text] }
 
 -- Function hydrating a DOM with elementse from the state
 makeP = (\name age ->
-  [hsx'|<p>#t{concat [name, " is the name and ", show age, " is my age."]}#</p>|])
+  [pwx'|<p>#t{concat [name, " is the name and ", show age, " is my age."]}#</p>|])
     <$> _name
     <*> _age
 
--- The same function using functional tags instead of hsx
+-- The same function using functional tags instead of pwx
 makeP = (\name age ->
     p'__ concat [name, " is the name and ", show age, " is my age."])
       <$> _name
@@ -115,9 +115,9 @@ HTML-creation functions can be nested, allowing for powerful abstractions:
 nested = div_ (take 10 $ repeat makeP)
 ```
 
-### HSX
+### PWX
 
-`hsx` is similar to [`jsx`](https://reactjs.org/docs/introducing-jsx.html). The main difference is that instead of only using `{}`, `hsx` uses four different varieties of `#{}#`:
+`pwx` is similar to [`jsx`](https://reactjs.org/docs/introducing-jsx.html). The main difference is that instead of only using `{}`, `pwx` uses four different varieties of `#{}#`:
 
 - `#e{}#` for a single element.
 - `#el{}#` for a list of elements.
@@ -126,7 +126,7 @@ nested = div_ (take 10 $ repeat makeP)
 
 ### Hydrating with a state
 
-HTML-creation functions use an apostrophe after the tag name (ie `div'`) if they accept arguments from a state and no apostrophe (ie `div`) if they don't. The same is true of `hsx`, ie `[hsx|<br />|]` versus `(s -> [hsx'|<br />|])`. 
+HTML-creation functions use an apostrophe after the tag name (ie `div'`) if they accept arguments from a state and no apostrophe (ie `div`) if they don't. The same is true of `pwx`, ie `[pwx|<br />|]` versus `(s -> [pwx'|<br />|])`. 
 
 Additionally, HTML-creation functions for tags that don't have any attributes (class, style, etc) are marked with a trailing underscore (ie `div_ [p__ "hello"]`), and tags that only accept text are marked with two trailing underscores (ie `p__ "hello"`).
 
@@ -139,7 +139,7 @@ For example, if the state is an integer, a valid event handler could be:
 ```haskell
 eh :: opq -> Int -> IO Int
 eh _ i = pure $ i + 1
-dom = [hsx|<button click=#c{eh}#>Click here</button>|]
+dom = [pwx|<button click=#c{eh}#>Click here</button>|]
 ```
 
 To handle events, you can use one of the functions exported by `Web.Framework.Plzwrk`. This could be useful to extract values from input events, for instance. Please see the [Hackage documentation](https://hackage.haskell.org/package/plzwrk) for more information.

--- a/hello-world/Main.hs
+++ b/hello-world/Main.hs
@@ -8,4 +8,4 @@ import           Web.Framework.Plzwrk.Tag       ( p__ )
 main :: IO ()
 main = do
   browser <- asteriusBrowser
-  plzwrk'_ [hsx|<p>Hello world!</p>|] browser
+  plzwrk'_ [pwx|<p>Hello world!</p>|] browser

--- a/plzwrk.cabal
+++ b/plzwrk.cabal
@@ -57,6 +57,7 @@ library
     , haskell-src-meta >= 0.8.5 && < 0.9
     , mtl >= 2.2.2 && < 2.3
     , parsec >= 3.1.14 && < 3.2
+    , monad-logger >= 0.3.32 && < 0.4
     , split >= 0.2.3 && < 0.3
     , template-haskell >= 2.14.0 && < 2.16
     , text >= 1.2.3 && < 1.3

--- a/plzwrk.cabal
+++ b/plzwrk.cabal
@@ -44,8 +44,8 @@ library
     , Web.Framework.Plzwrk.JSEnv
     , Web.Framework.Plzwrk.Domify
     , Web.Framework.Plzwrk.Util
-    , Web.Framework.Plzwrk.TH.HSX
-    , Web.Framework.Plzwrk.TH.QuoteHSX
+    , Web.Framework.Plzwrk.TH.PWX
+    , Web.Framework.Plzwrk.TH.QuotePWX
   hs-source-dirs:
       src
   build-depends:
@@ -75,7 +75,7 @@ test-suite plzwrk-test
   main-is: Spec.hs
   other-modules:
       DOMSpec
-    , HSXSpec
+    , PWXSpec
     , Paths_plzwrk
   hs-source-dirs:
       test

--- a/plzwrk.cabal
+++ b/plzwrk.cabal
@@ -86,5 +86,6 @@ test-suite plzwrk-test
     , mtl >=2.2.2 && <2.3
     , plzwrk
     , text >=1.2.3 && <1.3
+    , monad-logger >=0.3.32 && <0.4
     , unordered-containers >=0.2.10 && <0.3
   default-language: Haskell2010

--- a/src/Web/Framework/Plzwrk.hs
+++ b/src/Web/Framework/Plzwrk.hs
@@ -22,14 +22,14 @@ module Web.Framework.Plzwrk
   , PwNode(..)
   , PwAttribute(..)
   , JSEnv(..)
-  -- hsx
-  , hsx
-  , hsx'
+  -- pwx
+  , pwx
+  , pwx'
   , plusplus
-  , parseHSX
-  , parseHSX_
-  , HSX(..)
-  , HSXAttribute(..)
+  , parsePWX
+  , parsePWX_
+  , PWX(..)
+  , PWXAttribute(..)
   -- util
   , pF
   , pT
@@ -61,5 +61,5 @@ import           Web.Framework.Plzwrk.Base
 import           Web.Framework.Plzwrk.JSEnv
 import           Web.Framework.Plzwrk.Domify
 import           Web.Framework.Plzwrk.Util
-import           Web.Framework.Plzwrk.TH.HSX
-import           Web.Framework.Plzwrk.TH.QuoteHSX
+import           Web.Framework.Plzwrk.TH.PWX
+import           Web.Framework.Plzwrk.TH.QuotePWX

--- a/src/Web/Framework/Plzwrk.hs
+++ b/src/Web/Framework/Plzwrk.hs
@@ -26,6 +26,10 @@ module Web.Framework.Plzwrk
   , hsx
   , hsx'
   , plusplus
+  , parseHSX
+  , parseHSX_
+  , HSX(..)
+  , HSXAttribute(..)
   -- util
   , pF
   , pT
@@ -57,4 +61,5 @@ import           Web.Framework.Plzwrk.Base
 import           Web.Framework.Plzwrk.JSEnv
 import           Web.Framework.Plzwrk.Domify
 import           Web.Framework.Plzwrk.Util
+import           Web.Framework.Plzwrk.TH.HSX
 import           Web.Framework.Plzwrk.TH.QuoteHSX

--- a/src/Web/Framework/Plzwrk/TH/HSX.hs
+++ b/src/Web/Framework/Plzwrk/TH/HSX.hs
@@ -136,22 +136,19 @@ attribute = do
 ws :: MonadLoggerIO m => HSXParser m ()
 ws = void $ many $ oneOf " \t\r\n"
 
-p :: MonadLoggerIO m => String -> Int -> Int -> HSXParser (NoLoggingT m) HSX
-p file line col = do
-  updatePosition file line col
-  ws
-  e <- hsx
-  ws
-  eof
-  return e
-
-
 parseHSX :: (MF.MonadFail m, MonadLoggerIO m) => (String, Int, Int) -> String -> m HSX
 parseHSX (file, line, col) s = do
-  res <- runNoLoggingT (runParserT (p file line col) () "" s)
+  res <- runNoLoggingT (NoLoggingT (runParserT p () "" s))
   case res of
     Left err -> MF.fail $ show err
     Right e  -> return e
+  where p = do
+    updatePosition file line col
+    ws
+    e <- hsx
+    ws
+    eof
+    return e
 
 updatePosition file line col = do
   pos <- getPosition

--- a/src/Web/Framework/Plzwrk/TH/PWX.hs
+++ b/src/Web/Framework/Plzwrk/TH/PWX.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Web.Framework.Plzwrk.TH.HSX
-  ( HSXAttribute(..)
-  , HSX(..)
-  , parseHSX
-  , parseHSX_
+module Web.Framework.Plzwrk.TH.PWX
+  ( PWXAttribute(..)
+  , PWX(..)
+  , parsePWX
+  , parsePWX_
   ------------ for debugging
   , endTag
-  , elementHSXBody
+  , elementPWXBody
   , attribute
   , tag
   , text
@@ -33,31 +33,31 @@ import qualified Data.Text                     as T
 import           Text.Parsec
 import           Text.Parsec.String
 
-type HSXParser = ParsecT String ()
+type PWXParser = ParsecT String ()
 
-data HSXAttribute = HSXStringAttribute String
-                 | HSXHaskellCodeAttribute String
-                 | HSXHaskellTxtAttribute String deriving (Show, Eq)
+data PWXAttribute = PWXStringAttribute String
+                 | PWXHaskellCodeAttribute String
+                 | PWXHaskellTxtAttribute String deriving (Show, Eq)
 
-data HSX = HSXElement
-            { _hsxElement_tag :: String
-            , _hsxElement_attributes :: [(String, HSXAttribute)]
-            , _hsxElement_children :: [HSX]
+data PWX = PWXElement
+            { _pwxElement_tag :: String
+            , _pwxElement_attributes :: [(String, PWXAttribute)]
+            , _pwxElement_children :: [PWX]
             }
-            | HSXSelfClosingTag
-            { _hsxSelfClosingTag_tag :: String
-            , _hsxSelfClosingTag_attributes :: [(String, HSXAttribute)]
+            | PWXSelfClosingTag
+            { _pwxSelfClosingTag_tag :: String
+            , _pwxSelfClosingTag_attributes :: [(String, PWXAttribute)]
             }
-            | HSXHaskellCode { _hsxHaskellCode_code :: String }
-            | HSXHaskellCodeList { _hsxHaskellCodeList_codeList :: String }
-            | HSXHaskellText { _hsxHaskellText_text :: String }
-            | HSXBody { _hsxBody_body :: String }
+            | PWXHaskellCode { _pwxHaskellCode_code :: String }
+            | PWXHaskellCodeList { _pwxHaskellCodeList_codeList :: String }
+            | PWXHaskellText { _pwxHaskellText_text :: String }
+            | PWXBody { _pwxBody_body :: String }
           deriving (Show, Eq)
 
-hsx :: MonadLoggerIO m => HSXParser m HSX
-hsx = tag
+pwx :: MonadLoggerIO m => PWXParser m PWX
+pwx = tag
 
-tag :: MonadLoggerIO m => HSXParser m HSX
+tag :: MonadLoggerIO m => PWXParser m PWX
 tag = do
   lift $ logDebugN "starting tag"
   char '<'
@@ -72,15 +72,15 @@ tag = do
   close <- try (string "/>" <|> string ">")
   lift $ logDebugN (T.unwords $ fmap T.pack ["consumed close", close])
   if length close == 2
-    then return (HSXSelfClosingTag name attr)
+    then return (PWXSelfClosingTag name attr)
     else do
-      elementBody <- many elementHSXBody
+      elementBody <- many elementPWXBody
       endTag name
       ws
-      return (HSXElement name attr elementBody)
+      return (PWXElement name attr elementBody)
 
-elementHSXBody :: MonadLoggerIO m => HSXParser m HSX
-elementHSXBody =
+elementPWXBody :: MonadLoggerIO m => PWXParser m PWX
+elementPWXBody =
   ws
     *> (   try tag
        <|> try haskellCodeNode
@@ -90,22 +90,22 @@ elementHSXBody =
        <?> "A tag, a piece of code or some text"
        )
 
-endTag :: MonadLoggerIO m => String -> HSXParser m String
+endTag :: MonadLoggerIO m => String -> PWXParser m String
 endTag str = string "</" *> string str <* char '>'
 
-text :: MonadLoggerIO m => HSXParser m HSX
-text = HSXBody <$> many1 (noneOf "><")
+text :: MonadLoggerIO m => PWXParser m PWX
+text = PWXBody <$> many1 (noneOf "><")
 
-stringAttribute :: MonadLoggerIO m => HSXParser m HSXAttribute
+stringAttribute :: MonadLoggerIO m => PWXParser m PWXAttribute
 stringAttribute = do
   lift $ logDebugN "  continuing string attribute"
   char '"'
   value <- many (noneOf ['"'])
   char '"'
   lift $ logDebugN (T.unwords $ fmap T.pack ["finishing attribute", value])
-  return $ HSXStringAttribute value
+  return $ PWXStringAttribute value
 
-makeBracketed :: MonadLoggerIO m => String -> Bool -> HSXParser m String
+makeBracketed :: MonadLoggerIO m => String -> Bool -> PWXParser m String
 makeBracketed cmd contain = do
   lift $ logDebugN $ T.pack ("starting bracketed command " <> cmd)
   let start = "#" <> cmd <> "{"
@@ -116,32 +116,32 @@ makeBracketed cmd contain = do
   lift $ logDebugN (T.unwords $ fmap T.pack ["found bracketed command", cmd])
   return $ if contain then start <> value <> end else value
 
-haskellCodeAttr :: MonadLoggerIO m => HSXParser m HSXAttribute
+haskellCodeAttr :: MonadLoggerIO m => PWXParser m PWXAttribute
 haskellCodeAttr = do
   value <- makeBracketed "c" False
-  return $ HSXHaskellCodeAttribute value
+  return $ PWXHaskellCodeAttribute value
 
-haskellCodeNode :: MonadLoggerIO m => HSXParser m HSX
+haskellCodeNode :: MonadLoggerIO m => PWXParser m PWX
 haskellCodeNode = do
   value <- makeBracketed "e" False
-  return $ HSXHaskellCode value
+  return $ PWXHaskellCode value
 
-haskellCodeNodes :: MonadLoggerIO m => HSXParser m HSX
+haskellCodeNodes :: MonadLoggerIO m => PWXParser m PWX
 haskellCodeNodes = do
   value <- makeBracketed "el" False
-  return $ HSXHaskellCodeList value
+  return $ PWXHaskellCodeList value
 
-haskellTxtNode :: MonadLoggerIO m => HSXParser m HSX
+haskellTxtNode :: MonadLoggerIO m => PWXParser m PWX
 haskellTxtNode = do
   value <- makeBracketed "t" False
-  return $ HSXHaskellText value
+  return $ PWXHaskellText value
 
-haskellTxtAttr :: MonadLoggerIO m => HSXParser m HSXAttribute
+haskellTxtAttr :: MonadLoggerIO m => PWXParser m PWXAttribute
 haskellTxtAttr = do
   value <- makeBracketed "t" False
-  return $ HSXHaskellTxtAttribute value
+  return $ PWXHaskellTxtAttribute value
 
-attribute :: MonadLoggerIO m => HSXParser m (String, HSXAttribute)
+attribute :: MonadLoggerIO m => PWXParser m (String, PWXAttribute)
 attribute = do
   lift $ logDebugN "starting attribute"
   name <- many (noneOf "= />")
@@ -154,18 +154,18 @@ attribute = do
   lift $ logDebugN (T.unwords $ fmap T.pack ["finishing attribute", name])
   return (name, value)
 
-ws :: MonadLoggerIO m => HSXParser m ()
+ws :: MonadLoggerIO m => PWXParser m ()
 ws = void $ many $ oneOf " \t\r\n"
 
-parseHSX_ :: (MonadLoggerIO m) => String -> m HSX
-parseHSX_ s = do
-  res <- runParserT hsx () "" s
+parsePWX_ :: (MonadLoggerIO m) => String -> m PWX
+parsePWX_ s = do
+  res <- runParserT pwx () "" s
   case res of
     Left  err -> error $ show err
     Right e   -> return e
 
-parseHSX :: (MonadLoggerIO m) => (String, Int, Int) -> String -> m HSX
-parseHSX (file, line, col) s = do
+parsePWX :: (MonadLoggerIO m) => (String, Int, Int) -> String -> m PWX
+parsePWX (file, line, col) s = do
   res <- runParserT p () "" s
   case res of
     Left  err -> error $ show err
@@ -174,7 +174,7 @@ parseHSX (file, line, col) s = do
   p = do
     updatePosition file line col
     ws
-    e <- hsx
+    e <- pwx
     ws
     eof
     return e

--- a/src/Web/Framework/Plzwrk/TH/QuoteHSX.hs
+++ b/src/Web/Framework/Plzwrk/TH/QuoteHSX.hs
@@ -108,7 +108,7 @@ hsxToExpQ lam returnAsList (HSXBody b) = asList
   $ TH.appE (TH.conE (TH.mkName "PwTextNode")) (TH.litE (TH.StringL b))
   )
 
-instance MonadLogger TH.Q where monadLoggerLog _ _ _ = return $ TH.reportWarning "Using monad logger"
+instance MonadLogger TH.Q where monadLoggerLog _ _ _ = return $ return ()
 instance MonadLoggerIO TH.Q where askLoggerIO = return (\_ _ _ _ -> return ())
 
 quoteExprExp :: Bool -> String -> TH.Q TH.Exp

--- a/src/Web/Framework/Plzwrk/TH/QuoteHSX.hs
+++ b/src/Web/Framework/Plzwrk/TH/QuoteHSX.hs
@@ -5,6 +5,8 @@ module Web.Framework.Plzwrk.TH.QuoteHSX
   )
 where
 
+import Control.Monad.Logger
+import qualified Control.Monad.Trans as Trans
 import           Data.List.Split
 import qualified Data.Hashable                 as H
 import qualified Language.Haskell.TH           as TH
@@ -106,6 +108,10 @@ hsxToExpQ lam returnAsList (HSXBody b) = asList
   $ TH.appE (TH.conE (TH.mkName "PwTextNode")) (TH.litE (TH.StringL b))
   )
 
+instance MonadLogger TH.Q where monadLoggerLog _ _ _ = return $ TH.reportWarning "Using monad logger"
+instance MonadLoggerIO TH.Q where askLoggerIO = return (\_ _ _ _ -> return ())
+
+quoteExprExp :: Bool -> String -> TH.Q TH.Exp
 quoteExprExp b s = do
   pos    <- getPosition
   result <- parseHSX pos s

--- a/src/Web/Framework/Plzwrk/TH/QuotePWX.hs
+++ b/src/Web/Framework/Plzwrk/TH/QuotePWX.hs
@@ -1,6 +1,6 @@
-module Web.Framework.Plzwrk.TH.QuoteHSX
-  ( hsx
-  , hsx'
+module Web.Framework.Plzwrk.TH.QuotePWX
+  ( pwx
+  , pwx'
   , plusplus
   )
 where
@@ -13,21 +13,21 @@ import qualified Language.Haskell.TH           as TH
 import           Language.Haskell.Meta.Parse    ( parseExp )
 import           Language.Haskell.TH.Quote
 import           Language.Haskell.TH.Syntax
-import           Web.Framework.Plzwrk.TH.HSX
+import           Web.Framework.Plzwrk.TH.PWX
 import           Web.Framework.Plzwrk.Base
 import qualified Data.HashMap.Strict           as HM
 import qualified Data.Set                      as S
 
 
-hsx :: QuasiQuoter
-hsx = QuasiQuoter { quoteExp  = quoteExprExp True
+pwx :: QuasiQuoter
+pwx = QuasiQuoter { quoteExp  = quoteExprExp True
                   , quotePat  = undefined
                   , quoteDec  = undefined
                   , quoteType = undefined
                   }
 
-hsx' :: QuasiQuoter
-hsx' = QuasiQuoter { quoteExp  = quoteExprExp False
+pwx' :: QuasiQuoter
+pwx' = QuasiQuoter { quoteExp  = quoteExprExp False
                    , quotePat  = undefined
                    , quoteDec  = undefined
                    , quoteType = undefined
@@ -44,19 +44,19 @@ haskize y = either
 plusplus :: [a] -> [a] -> [a]
 plusplus = (++)
 
-hsxAttributeToExpQ :: (String, HSXAttribute) -> TH.Q TH.Exp
-hsxAttributeToExpQ (k, HSXStringAttribute v) = TH.tupE
+pwxAttributeToExpQ :: (String, PWXAttribute) -> TH.Q TH.Exp
+pwxAttributeToExpQ (k, PWXStringAttribute v) = TH.tupE
   [ TH.litE (TH.StringL k)
   , TH.lamE
     [TH.varP (TH.mkName "_")]
     (TH.appE (TH.conE (TH.mkName "PwTextAttribute")) (TH.litE (TH.StringL v)))
   ]
-hsxAttributeToExpQ (k, HSXHaskellCodeAttribute v) = TH.tupE
+pwxAttributeToExpQ (k, PWXHaskellCodeAttribute v) = TH.tupE
   [ TH.litE (TH.StringL k)
   , TH.lamE [TH.varP (TH.mkName "_")]
             (TH.appE (TH.conE (TH.mkName "PwFunctionAttribute")) (haskize v))
   ]
-hsxAttributeToExpQ (k, HSXHaskellTxtAttribute v) = TH.tupE
+pwxAttributeToExpQ (k, PWXHaskellTxtAttribute v) = TH.tupE
   [ TH.litE (TH.StringL k)
   , TH.lamE [TH.varP (TH.mkName "_")]
             (TH.appE (TH.conE (TH.mkName "PwTextAttribute")) (haskize v))
@@ -70,39 +70,39 @@ wrapInLambda False e = e
 asList :: Bool -> TH.Q TH.Exp -> TH.Q TH.Exp
 asList b e = if b then TH.listE [e] else e
 
-hsxToExpQ :: Bool -> Bool -> HSX -> TH.Q TH.Exp
-hsxToExpQ lam returnAsList (HSXHaskellCode y) = asList returnAsList (haskize y)
-hsxToExpQ lam returnAsList (HSXHaskellCodeList y) = haskize y
-hsxToExpQ lam returnAsList (HSXHaskellText y) = asList
+pwxToExpQ :: Bool -> Bool -> PWX -> TH.Q TH.Exp
+pwxToExpQ lam returnAsList (PWXHaskellCode y) = asList returnAsList (haskize y)
+pwxToExpQ lam returnAsList (PWXHaskellCodeList y) = haskize y
+pwxToExpQ lam returnAsList (PWXHaskellText y) = asList
   returnAsList
   (wrapInLambda True $ TH.appE (TH.conE (TH.mkName "PwTextNode")) (haskize y))
-hsxToExpQ lam returnAsList (HSXElement tag attrs elts) = asList
+pwxToExpQ lam returnAsList (PWXElement tag attrs elts) = asList
   returnAsList
   (wrapInLambda lam $ foldl
     TH.appE
     (TH.conE (TH.mkName "PwElement"))
     [ TH.litE (TH.StringL tag)
-    , TH.listE (fmap hsxAttributeToExpQ attrs)
+    , TH.listE (fmap pwxAttributeToExpQ attrs)
     , foldl
       TH.appE
       (TH.varE (TH.mkName "foldr"))
       [ TH.varE (TH.mkName "plusplus")
       , TH.conE (TH.mkName "[]")
-      , TH.listE (fmap (hsxToExpQ True True) elts)
+      , TH.listE (fmap (pwxToExpQ True True) elts)
       ]
     ]
   )
-hsxToExpQ lam returnAsList (HSXSelfClosingTag tag attrs) = asList
+pwxToExpQ lam returnAsList (PWXSelfClosingTag tag attrs) = asList
   returnAsList
   (wrapInLambda lam $ foldl
     TH.appE
     (TH.conE (TH.mkName "PwElement"))
     [ TH.litE (TH.StringL tag)
-    , TH.listE (fmap hsxAttributeToExpQ attrs)
+    , TH.listE (fmap pwxAttributeToExpQ attrs)
     , TH.conE (TH.mkName "[]")
     ]
   )
-hsxToExpQ lam returnAsList (HSXBody b) = asList
+pwxToExpQ lam returnAsList (PWXBody b) = asList
   returnAsList
   ( wrapInLambda lam
   $ TH.appE (TH.conE (TH.mkName "PwTextNode")) (TH.litE (TH.StringL b))
@@ -114,8 +114,8 @@ instance MonadLoggerIO TH.Q where askLoggerIO = return (\_ _ _ _ -> return ())
 quoteExprExp :: Bool -> String -> TH.Q TH.Exp
 quoteExprExp b s = do
   pos    <- getPosition
-  result <- parseHSX pos s
-  hsxToExpQ b False result
+  result <- parsePWX pos s
+  pwxToExpQ b False result
 
 getPosition = fmap transPos TH.location where
   transPos loc =

--- a/stack.yaml
+++ b/stack.yaml
@@ -48,12 +48,15 @@ extra-deps:
 - text-1.2.4.0
 - transformers-0.5.6.2
 - unordered-containers-0.2.10.0
+- monad-logger-0.3.32
 - mtl-2.2.2
 - neat-interpolation-0.5.1
 - split-0.2.3.4
 - haskell-src-meta-0.8.5
 - template-haskell-2.15.0.0
 - parsec-3.1.14.0@sha256:63a4555d6ea2aaccd8588fc809e5d137e72b668898ab3b171ce8458b792f0f36,4356
+#### for logger
+- Cabal-3.2.0.0@sha256:d0d7a1f405f25d0000f5ddef684838bc264842304fd4e7f80ca92b997b710874,27320
 #### for testing using keyvaluehash as our mock dom
 - hspec-2.7.1
 # Override default flag values for local packages and extra-deps

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -54,6 +54,13 @@ packages:
   original:
     hackage: unordered-containers-0.2.10.0
 - completed:
+    hackage: monad-logger-0.3.32@sha256:edb8a030012e4cf6dc19930ec36f846eeafcc9d871bd5bf0e863d78f6878b877,1755
+    pantry-tree:
+      size: 396
+      sha256: f32a5d7d04f45546ff60f78b0605bde8f5e7563802c7edb6e47e257102639966
+  original:
+    hackage: monad-logger-0.3.32
+- completed:
     hackage: mtl-2.2.2@sha256:1050fb71acd9f5d67da7d992583f5bd0eb14407b9dc7acc122af1b738b706ca3,2261
     pantry-tree:
       size: 1713
@@ -95,6 +102,13 @@ packages:
       sha256: c17cc12ba9a912521d58d8bcee07830351fe27483d9309ebdac8e32175e10706
   original:
     hackage: parsec-3.1.14.0@sha256:63a4555d6ea2aaccd8588fc809e5d137e72b668898ab3b171ce8458b792f0f36,4356
+- completed:
+    hackage: Cabal-3.2.0.0@sha256:d0d7a1f405f25d0000f5ddef684838bc264842304fd4e7f80ca92b997b710874,27320
+    pantry-tree:
+      size: 40963
+      sha256: b122f2d76dc82a350d3986fa0cbc4ecf9c3bb4f9c598ccbfb3b2bfdde02f3698
+  original:
+    hackage: Cabal-3.2.0.0@sha256:d0d7a1f405f25d0000f5ddef684838bc264842304fd4e7f80ca92b997b710874,27320
 - completed:
     hackage: hspec-2.7.1@sha256:0aa48928ce80a34f8ff8c5ef114bb6807edfb8d884bcd7211eceed710e7fb7a8,1769
     pantry-tree:

--- a/test/HSXSpec.hs
+++ b/test/HSXSpec.hs
@@ -11,6 +11,9 @@ import           Control.Monad.Reader
 import           Data.IORef
 import           Test.Hspec
 import           Web.Framework.Plzwrk
+import           Control.Monad.Logger
+
+genericLogger _ _ _ = print
 
 hsxSpec = describe "HSXParser" $ do
   it "Parses simple hsx" $ do
@@ -27,7 +30,7 @@ hsxSpec = describe "HSXParser" $ do
         |]
     _elt_tag (dom 3) `shouldBe` "h1"
     _elt_tag (((_elt_children (dom 5)) !! 0) 3) `shouldBe` "a"
-    let attrs = (_elt_attrs (((_elt_children (dom 1)) !! 0) 1))
+    let attrs     = (_elt_attrs (((_elt_children (dom 1)) !! 0) 1))
     let clickAttr = (filter (\(x, _) -> x == "click") attrs) !! 0
     let mf (PwFunctionAttribute f) = f
     let cf = mf ((snd clickAttr) 0)
@@ -47,7 +50,9 @@ hsxSpec = describe "HSXParser" $ do
     1 `shouldBe` 1
   it "Parses terse hsx with sub-hsx" $ do
     let mylink = [hsx|<a click=#c{(\_ x -> return $ x + 41)}#>Hello</a>|]
-    let dom = [hsx|<h1 id="foo" style="position:absolute">#e{mylink}##t{"hello world"}#</h1>|]
+    let
+      dom
+        = [hsx|<h1 id="foo" style="position:absolute">#e{mylink}##t{"hello world"}#</h1>|]
     _elt_tag (dom 3) `shouldBe` "h1"
     _elt_tag (head (_elt_children (dom 5)) 3) `shouldBe` "a"
     _tn_text ((_elt_children (dom 5) !! 1) 3) `shouldBe` "hello world"
@@ -73,13 +78,46 @@ hsxSpec = describe "HSXParser" $ do
         |]
     _elt_tag (dom 3) `shouldBe` "h1"
     _elt_tag (head (_elt_children (dom 5)) 3) `shouldBe` "div"
-    _elt_tag ((_elt_children (head (_elt_children (dom 5)) 3) !! 1) 5) `shouldBe` "span"
+    _elt_tag ((_elt_children (head (_elt_children (dom 5)) 3) !! 1) 5)
+      `shouldBe` "span"
   it "Parses hsx'" $ do
     let mylink = [hsx|<a click=#c{(\_ x -> return $ x + 41)}#>Hello</a>|]
-    let dom = (\st -> [hsx'|
+    let dom =
+          (\st -> [hsx'|
             <h1 id="foo" style=#t{"position:absolute"}#>
                 #e{mylink}#
             </h1>
-        |])
+        |]
+          )
     _elt_tag (dom 3) `shouldBe` "h1"
     _elt_tag (head (_elt_children (dom 5)) 3) `shouldBe` "a"
+  it "Handles <br />" $ do
+    -- we can check this later, for now we just make sure it parses
+    v <- runNoLoggingT (parseHSX_ "<br />")
+    _hsxSelfClosingTag_tag v `shouldBe` "br"
+    _hsxSelfClosingTag_attributes v `shouldBe` []
+  it "Handles nested elements" $ do
+    -- we can check this later, for now we just make sure it parses
+    v <- runNoLoggingT
+      (parseHSX_ "<div>  \n  <span>a</span>   hello <span></span>world </div>")
+    _hsxElement_tag v `shouldBe` "div"
+  it "Handles terse nested elements" $ do
+    -- we can check this later, for now we just make sure it parses
+    v <- runNoLoggingT
+      (parseHSX_ "<div><span>a</span>hello<span></span>world</div>")
+    _hsxElement_tag v `shouldBe` "div"
+  it "Handles terse nested elements with dynamic text" $ do
+    -- we can check this later, for now we just make sure it parses
+    v <- runNoLoggingT
+      (parseHSX_
+        "<div><span>a</span>hello<span>#t{\"there\"}#</span>#t{\"world\"}#</div>"
+      )
+    _hsxElement_tag v `shouldBe` "div"
+  it "Handles double back-to-back brackets" $ do
+    -- we can check this later, for now we just make sure it parses
+    v <- runNoLoggingT (parseHSX_ "<div click=#c{\\_ s -> s { _foo=1 } }# />")
+    _hsxElement_tag v `shouldBe` "div"
+  it "Handles double back-to-back brackets with no whitespace" $ do
+  -- we can check this later, for now we just make sure it parses
+    v <- runNoLoggingT (parseHSX_ "<div click=#c{\\_ s -> s { _foo=1 }}# />")
+    _hsxElement_tag v `shouldBe` "div"

--- a/test/PWXSpec.hs
+++ b/test/PWXSpec.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE QuasiQuotes #-}
 
-module HSXSpec
-  ( hsxSpec
+module PWXSpec
+  ( pwxSpec
   )
 where
 
@@ -15,15 +15,15 @@ import           Control.Monad.Logger
 
 genericLogger _ _ _ = print
 
-hsxSpec = describe "HSXParser" $ do
-  it "Parses simple hsx" $ do
-    let dom = [hsx|<p>Hello world!</p>|]
+pwxSpec = describe "PWXParser" $ do
+  it "Parses simple pwx" $ do
+    let dom = [pwx|<p>Hello world!</p>|]
     -- we use () for an empty state
 
     _elt_tag (dom ()) `shouldBe` "p"
     _tn_text (head (_elt_children (dom ())) ()) `shouldBe` "Hello world!"
-  it "Parses hsx with an event listener" $ do
-    let dom = [hsx|
+  it "Parses pwx with an event listener" $ do
+    let dom = [pwx|
             <h1 id="foo" style="position:absolute">
                 <a click=#c{(\_ x -> return $ x + 41)}#>Hello</a>
             </h1>
@@ -36,9 +36,9 @@ hsxSpec = describe "HSXParser" $ do
     let cf = mf ((snd clickAttr) 0)
     res <- cf () 1
     res `shouldBe` 42
-  it "Parses hsx with sub-hsx" $ do
-    let mylink = [hsx|<a click=#c{(\_ x -> return $ x + 41)}#>Hello</a>|]
-    let dom = [hsx|
+  it "Parses pwx with sub-pwx" $ do
+    let mylink = [pwx|<a click=#c{(\_ x -> return $ x + 41)}#>Hello</a>|]
+    let dom = [pwx|
             <h1 id="foo" style="position:absolute">
                 #e{mylink}#
                 #t{"hello world"}#
@@ -48,18 +48,18 @@ hsxSpec = describe "HSXParser" $ do
     _elt_tag (head (_elt_children (dom 5)) 3) `shouldBe` "a"
     _tn_text ((_elt_children (dom 5) !! 1) 3) `shouldBe` "hello world"
     1 `shouldBe` 1
-  it "Parses terse hsx with sub-hsx" $ do
-    let mylink = [hsx|<a click=#c{(\_ x -> return $ x + 41)}#>Hello</a>|]
+  it "Parses terse pwx with sub-pwx" $ do
+    let mylink = [pwx|<a click=#c{(\_ x -> return $ x + 41)}#>Hello</a>|]
     let
       dom
-        = [hsx|<h1 id="foo" style="position:absolute">#e{mylink}##t{"hello world"}#</h1>|]
+        = [pwx|<h1 id="foo" style="position:absolute">#e{mylink}##t{"hello world"}#</h1>|]
     _elt_tag (dom 3) `shouldBe` "h1"
     _elt_tag (head (_elt_children (dom 5)) 3) `shouldBe` "a"
     _tn_text ((_elt_children (dom 5) !! 1) 3) `shouldBe` "hello world"
     1 `shouldBe` 1
-  it "Parses hsx with a list of elements" $ do
-    let mylink = [hsx|<a click=#c{(\_ x -> return $ x + 41)}#>Hello</a>|]
-    let dom = [hsx|
+  it "Parses pwx with a list of elements" $ do
+    let mylink = [pwx|<a click=#c{(\_ x -> return $ x + 41)}#>Hello</a>|]
+    let dom = [pwx|
             <h1 id="foo" style="position:absolute">
                 #el{take 10 $ repeat mylink}#
                 #t{"hello world"}#
@@ -69,9 +69,9 @@ hsxSpec = describe "HSXParser" $ do
     _elt_tag (head (_elt_children (dom 5)) 3) `shouldBe` "a"
     _elt_tag ((_elt_children (dom 5) !! 6) 3) `shouldBe` "a"
     _tn_text ((_elt_children (dom 5) !! 10) 3) `shouldBe` "hello world"
-  it "Parses hsx mixing text and not text" $ do
-    let mylink = [hsx|<a click=#c{(\_ x -> return $ x + 41)}#>Hello</a>|]
-    let dom = [hsx|
+  it "Parses pwx mixing text and not text" $ do
+    let mylink = [pwx|<a click=#c{(\_ x -> return $ x + 41)}#>Hello</a>|]
+    let dom = [pwx|
             <h1 id="foo" style="position:absolute">
                 <div>Hello <span>world</span> </div>
             </h1>
@@ -80,10 +80,10 @@ hsxSpec = describe "HSXParser" $ do
     _elt_tag (head (_elt_children (dom 5)) 3) `shouldBe` "div"
     _elt_tag ((_elt_children (head (_elt_children (dom 5)) 3) !! 1) 5)
       `shouldBe` "span"
-  it "Parses hsx'" $ do
-    let mylink = [hsx|<a click=#c{(\_ x -> return $ x + 41)}#>Hello</a>|]
+  it "Parses pwx'" $ do
+    let mylink = [pwx|<a click=#c{(\_ x -> return $ x + 41)}#>Hello</a>|]
     let dom =
-          (\st -> [hsx'|
+          (\st -> [pwx'|
             <h1 id="foo" style=#t{"position:absolute"}#>
                 #e{mylink}#
             </h1>
@@ -93,31 +93,31 @@ hsxSpec = describe "HSXParser" $ do
     _elt_tag (head (_elt_children (dom 5)) 3) `shouldBe` "a"
   it "Handles <br />" $ do
     -- we can check this later, for now we just make sure it parses
-    v <- runNoLoggingT (parseHSX_ "<br />")
-    _hsxSelfClosingTag_tag v `shouldBe` "br"
-    _hsxSelfClosingTag_attributes v `shouldBe` []
+    v <- runNoLoggingT (parsePWX_ "<br />")
+    _pwxSelfClosingTag_tag v `shouldBe` "br"
+    _pwxSelfClosingTag_attributes v `shouldBe` []
   it "Handles nested elements" $ do
     -- we can check this later, for now we just make sure it parses
     v <- runNoLoggingT
-      (parseHSX_ "<div>  \n  <span>a</span>   hello <span></span>world </div>")
-    _hsxElement_tag v `shouldBe` "div"
+      (parsePWX_ "<div>  \n  <span>a</span>   hello <span></span>world </div>")
+    _pwxElement_tag v `shouldBe` "div"
   it "Handles terse nested elements" $ do
     -- we can check this later, for now we just make sure it parses
     v <- runNoLoggingT
-      (parseHSX_ "<div><span>a</span>hello<span></span>world</div>")
-    _hsxElement_tag v `shouldBe` "div"
+      (parsePWX_ "<div><span>a</span>hello<span></span>world</div>")
+    _pwxElement_tag v `shouldBe` "div"
   it "Handles terse nested elements with dynamic text" $ do
     -- we can check this later, for now we just make sure it parses
     v <- runNoLoggingT
-      (parseHSX_
+      (parsePWX_
         "<div><span>a</span>hello<span>#t{\"there\"}#</span>#t{\"world\"}#</div>"
       )
-    _hsxElement_tag v `shouldBe` "div"
+    _pwxElement_tag v `shouldBe` "div"
   it "Handles double back-to-back brackets" $ do
     -- we can check this later, for now we just make sure it parses
-    v <- runNoLoggingT (parseHSX_ "<div click=#c{\\_ s -> s { _foo=1 } }# />")
-    _hsxElement_tag v `shouldBe` "div"
+    v <- runNoLoggingT (parsePWX_ "<div click=#c{\\_ s -> s { _foo=1 } }# />")
+    _pwxSelfClosingTag_tag v `shouldBe` "div"
   it "Handles double back-to-back brackets with no whitespace" $ do
   -- we can check this later, for now we just make sure it parses
-    v <- runNoLoggingT (parseHSX_ "<div click=#c{\\_ s -> s { _foo=1 }}# />")
-    _hsxElement_tag v `shouldBe` "div"
+    v <- runNoLoggingT (parsePWX_ "<div click=#c{\\_ s -> s { _foo=1 }}# />")
+    _pwxSelfClosingTag_tag v `shouldBe` "div"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,8 +1,8 @@
 import DOMSpec ( domSpec )
-import HSXSpec ( hsxSpec )
+import PWXSpec ( pwxSpec )
 import           Test.Hspec
 
 main :: IO ()
 main = hspec $ do
   domSpec
-  hsxSpec
+  pwxSpec


### PR DESCRIPTION
Uses `Control.Monad.Logger` to allow for logging in the parser for easier debugging.